### PR TITLE
Fix CMA-ES start

### DIFF
--- a/python/optimizers.py
+++ b/python/optimizers.py
@@ -39,8 +39,10 @@ def run_cma_es(
 
     Returns:
         Tuple of best-found parameter vector and its SSE value.
+
+    The optimizer starts from the midpoint of each parameter bound.
     """
-    x0 = _lhs_samples(bounds, 1, random_seed)[0]
+    x0 = np.array([(lb + ub) / 2 for lb, ub in bounds])
     sigma0 = 0.25 * np.mean([ub - lb for lb, ub in bounds])
     popsize = 4 + int(3 * np.log(len(bounds)))
 


### PR DESCRIPTION
## Summary
- start CMA-ES from the midpoint of the search bounds

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c480a6cd88323b7341e24fd444e7c