### PR TITLE
Add evaluation limit handling for dual annealing

### DIFF
--- a/python/optimizers.py
+++ b/python/optimizers.py
@@ -174,7 +174,7 @@ def run_dual_annealing(
     bounds: list[tuple[float, float]],
     random_seed: int,
 ) -> tuple[np.ndarray, float]:
-    """Run Dual Annealing global optimization.
+    """Run Dual Annealing global optimization with an evaluation budget.
 
     Args:
         objective_tracker: Tracker providing the evaluate method.
@@ -186,13 +186,29 @@ def run_dual_annealing(
     """
     x0 = _lhs_samples(bounds, 1, random_seed)[0]
 
-    result = dual_annealing(
-        func=objective_tracker.evaluate,
-        bounds=bounds,
-        seed=random_seed,
-        maxfun=21000,
-        x0=x0,
-    )
+    budget = 21000
+    calls = 0
+
+    def wrapped(x: np.ndarray) -> float:
+        nonlocal calls
+        if calls >= budget:
+            raise StopIteration("Evaluation budget reached")
+        calls += 1
+        return objective_tracker.evaluate(x)
+
+    try:
+        result = dual_annealing(
+            func=wrapped,
+            bounds=bounds,
+            seed=random_seed,
+            maxfun=budget,
+            x0=x0,
+        )
+    except StopIteration:
+        best_idx = int(np.argmin([h["sse"] for h in objective_tracker.history]))
+        best_params = objective_tracker.history[best_idx]["params"]
+        best_sse = objective_tracker.history[best_idx]["sse"]
+        return np.array(best_params), float(best_sse)
 
     return np.array(result.x), float(result.fun)
 


### PR DESCRIPTION
## Summary
- wrap dual annealing objective to stop at evaluation budget like in L-SHADE
- return best-so-far parameters when the budget is hit

## Testing
- `flake8 python/optimizers.py`
- `pylint python/optimizers.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6873a31ecefc83238c83d990ac33c5ef