### PR TITLE
Stop showing figures in plot_results

### DIFF
--- a/python/plot_results.py
+++ b/python/plot_results.py
@@ -354,7 +354,7 @@ def plot_parameter_recovery() -> None:
 
     plt.tight_layout()
     plt.savefig("plots/param_recovery.png", dpi=300)
-    plt.show()
+    plt.close()
 
 
 def plot_parameter_recovery_excluding_own() -> None:
@@ -406,7 +406,7 @@ def plot_parameter_recovery_excluding_own() -> None:
 
     plt.tight_layout()
     plt.savefig("plots/param_recovery_exclusion.png", dpi=300)
-    plt.show()
+    plt.close()
 
 
 # ---------------------------------------------------------------------------
@@ -521,7 +521,7 @@ def plot_synthetic_swarm() -> None:
 
     plt.tight_layout()
     plt.savefig("plots/rmse_syn.png")
-    plt.show()
+    plt.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure generated plots do not display

## Testing
- `ruff check python/plot_results.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8ebe45b08323ac14d6f11064abbc