### PR TITLE
Add scripts to generate optimization performance figures

### DIFF
--- a/generate_figures/generate_fig_1_fit_overlay.py
+++ b/generate_figures/generate_fig_1_fit_overlay.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Generate Figure 1: Model Fits and Variability on Experimental Data.
+
+This script overlays experimental GFP measurements with simulated traces from
+multiple optimizers. The median and interquartile range (IQR) of the simulated
+traces are shown to highlight run-to-run variability.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import List
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.io import loadmat
+
+# Ensure the `python` directory is on the Python path for importing helpers.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT / "python"))
+
+from generate_data import MODEL_PARAMS  # noqa: E402
+from simulate import simulate_variant_response  # noqa: E402
+
+ORDER = ["CMA-ES", "Basin Hopping", "L-SHADE", "Dual Annealing", "PSO"]
+INTERNAL_NAMES = ["cmaes", "basin_hopping", "lshade", "dual_annealing", "pso"]
+DISPLAY_MAP = dict(zip(INTERNAL_NAMES, ORDER))
+COLORS = {
+    "CMA-ES": "#E67E22",
+    "Basin Hopping": "#F1C40F",
+    "L-SHADE": "#9B59B6",
+    "Dual Annealing": "#E91E63",
+    "PSO": "#3A86FF",
+}
+RESULTS_DIR = ROOT / "experimental_results"
+DATA_DIR = ROOT / "data"
+PLOTS_DIR = ROOT / "plots"
+VARIANT = "AAV"
+
+
+def _load_experimental_trace() -> np.ndarray:
+    """Load the experimental GFP time course for the AAV variant."""
+    mat = loadmat(DATA_DIR / "experimental_data.mat")
+    return mat[VARIANT].ravel().astype(float)
+
+
+def _simulate_runs(optimizer: str) -> np.ndarray:
+    """Return simulated traces for all runs of an optimizer.
+
+    Args:
+        optimizer: Internal optimizer name.
+
+    Returns:
+        Array of shape (runs, time) with simulated GFP traces.
+    """
+    traces: List[np.ndarray] = []
+    for run_idx in range(1, 14):
+        file_name = f"{optimizer}_history_variant_{VARIANT}_run_{run_idx}.csv"
+        path = RESULTS_DIR / file_name
+        if not path.exists():
+            continue
+        df = pd.read_csv(path)
+        best_row = df.loc[df["sse"].idxmin()]
+        params = np.asarray(ast.literal_eval(best_row["params"]), dtype=float)
+        sim = simulate_variant_response(
+            params=params, model_params=MODEL_PARAMS, variant=VARIANT
+        )
+        traces.append(sim)
+    return np.asarray(traces)
+
+
+def main() -> None:
+    """Create and save the fit overlay figure."""
+    plt.rcParams.update(
+        {
+            "font.size": 8,
+            "axes.labelsize": 8,
+            "xtick.labelsize": 7.5,
+            "ytick.labelsize": 7.5,
+            "legend.fontsize": 8,
+        }
+    )
+
+    exp_trace = _load_experimental_trace()
+    time_min = np.arange(0, exp_trace.size * 10, 10)
+
+    fig, ax = plt.subplots(figsize=(3.35, 2.8))
+    ax.plot(
+        time_min,
+        exp_trace,
+        "o",
+        color="black",
+        markersize=4,
+        label="Experimental",
+    )
+
+    for internal in INTERNAL_NAMES:
+        display = DISPLAY_MAP[internal]
+        traces = _simulate_runs(internal)
+        if traces.size == 0:
+            continue
+        median = np.quantile(traces, 0.5, axis=0)
+        q1 = np.quantile(traces, 0.25, axis=0)
+        q3 = np.quantile(traces, 0.75, axis=0)
+        ax.plot(time_min, median, color=COLORS[display], linewidth=1.0, label=display)
+        ax.fill_between(
+            time_min,
+            q1,
+            q3,
+            color=COLORS[display],
+            alpha=0.2,
+        )
+
+    ax.set_title("Model Fits and Variability on Experimental Data")
+    ax.set_xlabel("Time (min)")
+    ax.set_ylabel("GFP (AU)")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(PLOTS_DIR / "fig1_fit_overlay.pdf", bbox_inches="tight")
+    fig.savefig(
+        PLOTS_DIR / "fig1_fit_overlay.png", dpi=600, bbox_inches="tight"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_figures/generate_fig_2_convergence.py
+++ b/generate_figures/generate_fig_2_convergence.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Generate Figure 2: Convergence and Efficiency of Optimizers.
+
+The figure contains two panels showing convergence behaviour on experimental
+runs and the distribution of function evaluations required to reach a common
+RMSE threshold.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from scipy.io import loadmat
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT / "python"))
+
+ORDER = ["CMA-ES", "Basin Hopping", "L-SHADE", "Dual Annealing", "PSO"]
+INTERNAL_NAMES = ["cmaes", "basin_hopping", "lshade", "dual_annealing", "pso"]
+DISPLAY_MAP = dict(zip(INTERNAL_NAMES, ORDER))
+COLORS = {
+    "CMA-ES": "#E67E22",
+    "Basin Hopping": "#F1C40F",
+    "L-SHADE": "#9B59B6",
+    "Dual Annealing": "#E91E63",
+    "PSO": "#3A86FF",
+}
+RESULTS_DIR = ROOT / "experimental_results"
+DATA_DIR = ROOT / "data"
+PLOTS_DIR = ROOT / "plots"
+VARIANT = "AAV"
+MAX_EVALS = 5000
+
+
+def _load_experimental_trace() -> np.ndarray:
+    """Return the experimental GFP time course to determine trace length."""
+    mat = loadmat(DATA_DIR / "experimental_data.mat")
+    return mat[VARIANT].ravel().astype(float)
+
+
+def _load_histories() -> Dict[str, List[np.ndarray]]:
+    """Load RMSE histories for each optimizer.
+
+    Returns:
+        Mapping of display name to a list of RMSE arrays, each of length
+        ``MAX_EVALS`` with trailing ``NaN`` values if a run terminated early.
+    """
+    num_points = _load_experimental_trace().size
+    histories: Dict[str, List[np.ndarray]] = {name: [] for name in ORDER}
+    for internal in INTERNAL_NAMES:
+        display = DISPLAY_MAP[internal]
+        for run_idx in range(1, 14):
+            file_name = f"{internal}_history_variant_{VARIANT}_run_{run_idx}.csv"
+            path = RESULTS_DIR / file_name
+            if not path.exists():
+                continue
+            df = pd.read_csv(path)
+            sse = df["sse"].to_numpy(dtype=float)
+            rmse = np.sqrt(sse / num_points)
+            arr = np.full(MAX_EVALS, np.nan)
+            arr[: min(MAX_EVALS, rmse.size)] = rmse[:MAX_EVALS]
+            histories[display].append(arr)
+    return histories
+
+
+def _compute_threshold(histories: Dict[str, List[np.ndarray]]) -> float:
+    """Compute the median final RMSE across all runs."""
+    finals: List[float] = []
+    for runs in histories.values():
+        for arr in runs:
+            valid = arr[~np.isnan(arr)]
+            if valid.size > 0:
+                finals.append(float(valid[-1]))
+    return float(np.median(finals))
+
+
+def main() -> None:
+    """Create and save the convergence and efficiency figure."""
+    plt.rcParams.update(
+        {
+            "font.size": 8,
+            "axes.labelsize": 8,
+            "xtick.labelsize": 7.5,
+            "ytick.labelsize": 7.5,
+            "legend.fontsize": 8,
+        }
+    )
+
+    histories = _load_histories()
+    threshold = _compute_threshold(histories)
+    evals = np.arange(1, MAX_EVALS + 1)
+
+    fig, axes = plt.subplots(1, 2, figsize=(7.09, 3.5))
+
+    # Panel A: Convergence curves.
+    ax = axes[0]
+    for display in ORDER:
+        runs = histories.get(display, [])
+        if not runs:
+            continue
+        data = np.vstack(runs)
+        median = np.nanmedian(data, axis=0)
+        q1 = np.nanpercentile(data, 25, axis=0)
+        q3 = np.nanpercentile(data, 75, axis=0)
+        ax.plot(evals, median, color=COLORS[display], linewidth=1.0, label=display)
+        ax.fill_between(evals, q1, q3, color=COLORS[display], alpha=0.2)
+    ax.set_title("(A) Convergence on Experimental Data")
+    ax.set_xlabel("Function Evaluations")
+    ax.set_ylabel("RMSE (AU)")
+    ax.legend()
+
+    # Panel B: Evaluations to reach threshold RMSE.
+    records: List[Dict[str, float]] = []
+    for display, runs in histories.items():
+        for arr in runs:
+            indices = np.where(arr <= threshold)[0]
+            if indices.size > 0:
+                records.append({"optimizer": display, "evals": indices[0] + 1})
+    df = pd.DataFrame(records)
+    if not df.empty:
+        order = (
+            df.groupby("optimizer")["evals"].median().sort_values().index.tolist()
+        )
+    else:
+        order = ORDER
+    ax = axes[1]
+    sns.boxplot(
+        data=df,
+        x="optimizer",
+        y="evals",
+        order=order,
+        palette=[COLORS[o] for o in order],
+        ax=ax,
+    )
+    ax.set_title("(B) Evaluations to Reach Threshold RMSE")
+    ax.set_xlabel("Optimizer")
+    ax.set_ylabel("Function Evaluations")
+
+    fig.suptitle("Optimizer Convergence and Efficiency")
+    fig.tight_layout()
+    fig.savefig(PLOTS_DIR / "fig2_convergence.pdf", bbox_inches="tight")
+    fig.savefig(
+        PLOTS_DIR / "fig2_convergence.png", dpi=600, bbox_inches="tight"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_figures/generate_fig_3_recovery_heatmap.py
+++ b/generate_figures/generate_fig_3_recovery_heatmap.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Generate Figure 3: Cross-Recovery Heatmap of Parameter Accuracy."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT / "python"))
+
+ORDER = ["CMA-ES", "Basin Hopping", "L-SHADE", "Dual Annealing", "PSO"]
+DISPLAY_MAP = {
+    "cmaes": "CMA-ES",
+    "basin_hopping": "Basin Hopping",
+    "lshade": "L-SHADE",
+    "dual_annealing": "Dual Annealing",
+    "pso": "PSO",
+}
+COLORS = {
+    "CMA-ES": "#E67E22",
+    "Basin Hopping": "#F1C40F",
+    "L-SHADE": "#9B59B6",
+    "Dual Annealing": "#E91E63",
+    "PSO": "#3A86FF",
+}
+DATA_DIR = ROOT / "data"
+PLOTS_DIR = ROOT / "plots"
+
+LOWER_BOUNDS: Sequence[float] = [
+    0.0005,
+    0.0005,
+    0.0005,
+    0.0005,
+    0.0005,
+    0.0001,
+    0.0001,
+    0.00005,
+    0.0001,
+    0.0001,
+    0.00005,
+    100,
+    0.00000001,
+    100,
+    100,
+    100,
+    0.00000001,
+    0.00000001,
+    0.5,
+    0.0001,
+    100,
+]
+UPPER_BOUNDS: Sequence[float] = [
+    0.5,
+    0.5,
+    0.5,
+    0.5,
+    0.5,
+    0.01,
+    0.01,
+    0.01,
+    0.01,
+    0.01,
+    0.01,
+    1000000,
+    0.00001,
+    1000000,
+    1000000,
+    1000000,
+    0.00001,
+    0.00001,
+    5,
+    0.01,
+    1000000,
+]
+
+
+def _parse_params(param_str: str) -> np.ndarray:
+    """Parse a list-like parameter string into an array."""
+    return np.asarray(ast.literal_eval(param_str), dtype=float)
+
+
+def _load_ground_truth(category: str) -> np.ndarray:
+    """Load ground-truth parameters for a dataset category."""
+    df = pd.read_csv(DATA_DIR / f"{category}_best_params.csv")
+    return df.iloc[0].to_numpy(dtype=float)
+
+
+def _mase(found: Sequence[float], truth: Sequence[float]) -> float:
+    """Compute the Mean Absolute Scaled Error (MASE)."""
+    lb = np.asarray(LOWER_BOUNDS, dtype=float)
+    ub = np.asarray(UPPER_BOUNDS, dtype=float)
+    scale = ub - lb
+    found_scaled = (np.asarray(found, dtype=float) - lb) / scale
+    truth_scaled = (np.asarray(truth, dtype=float) - lb) / scale
+    return float(np.mean(np.abs(found_scaled - truth_scaled)))
+
+
+def main() -> None:
+    """Create and save the cross-recovery heatmap."""
+    plt.rcParams.update(
+        {
+            "font.size": 8,
+            "axes.labelsize": 8,
+            "xtick.labelsize": 7.5,
+            "ytick.labelsize": 7.5,
+            "legend.fontsize": 8,
+        }
+    )
+
+    df = pd.read_csv(ROOT / "synthetic_results.csv")
+    df["generator"] = df["dataset"].str.rsplit("_", n=1).str[0]
+    df["generator_display"] = df["generator"].map(DISPLAY_MAP)
+    df["optimizer_display"] = df["optimizer"].map(DISPLAY_MAP)
+
+    categories = df["generator"].unique()
+    truth = {cat: _load_ground_truth(cat) for cat in categories}
+    df["mase"] = df.apply(
+        lambda r: _mase(_parse_params(r["params"]), truth[r["generator"]]), axis=1
+    )
+
+    pivot = df.pivot_table(
+        index="generator_display",
+        columns="optimizer_display",
+        values="mase",
+        aggfunc=np.median,
+    )
+    pivot = pivot.loc[ORDER, ORDER]
+
+    fig, ax = plt.subplots(figsize=(7.09, 6.0))
+    sns.heatmap(
+        pivot,
+        annot=True,
+        fmt=".3f",
+        cmap="viridis",
+        cbar_kws={"label": "Median MASE"},
+        ax=ax,
+    )
+    ax.set_title("Parameter Recovery Performance (Median MASE)")
+    ax.set_xlabel("Fitting Optimizer")
+    ax.set_ylabel("Synthetic Data Generator")
+    ax.set_xticklabels(ax.get_xticklabels(), rotation=45, ha="right")
+    fig.tight_layout()
+    fig.savefig(PLOTS_DIR / "fig3_recovery_heatmap.pdf", bbox_inches="tight")
+    fig.savefig(
+        PLOTS_DIR / "fig3_recovery_heatmap.png", dpi=600, bbox_inches="tight"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_figures/generate_fig_4_fitness_vs_recovery.py
+++ b/generate_figures/generate_fig_4_fitness_vs_recovery.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Generate Figure 4: Fitness vs. Parameter Recovery Scatter Plot."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from scipy.io import loadmat
+from scipy.stats import spearmanr
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT / "python"))
+
+ORDER = ["CMA-ES", "Basin Hopping", "L-SHADE", "Dual Annealing", "PSO"]
+DISPLAY_MAP = {
+    "cmaes": "CMA-ES",
+    "basin_hopping": "Basin Hopping",
+    "lshade": "L-SHADE",
+    "dual_annealing": "Dual Annealing",
+    "pso": "PSO",
+}
+COLORS = {
+    "CMA-ES": "#E67E22",
+    "Basin Hopping": "#F1C40F",
+    "L-SHADE": "#9B59B6",
+    "Dual Annealing": "#E91E63",
+    "PSO": "#3A86FF",
+}
+DATA_DIR = ROOT / "data"
+PLOTS_DIR = ROOT / "plots"
+
+LOWER_BOUNDS: Sequence[float] = [
+    0.0005,
+    0.0005,
+    0.0005,
+    0.0005,
+    0.0005,
+    0.0001,
+    0.0001,
+    0.00005,
+    0.0001,
+    0.0001,
+    0.00005,
+    100,
+    0.00000001,
+    100,
+    100,
+    100,
+    0.00000001,
+    0.00000001,
+    0.5,
+    0.0001,
+    100,
+]
+UPPER_BOUNDS: Sequence[float] = [
+    0.5,
+    0.5,
+    0.5,
+    0.5,
+    0.5,
+    0.01,
+    0.01,
+    0.01,
+    0.01,
+    0.01,
+    0.01,
+    1000000,
+    0.00001,
+    1000000,
+    1000000,
+    1000000,
+    0.00001,
+    0.00001,
+    5,
+    0.01,
+    1000000,
+]
+
+
+def _parse_params(param_str: str) -> np.ndarray:
+    """Parse a list-like parameter string into an array."""
+    return np.asarray(ast.literal_eval(param_str), dtype=float)
+
+
+def _load_ground_truth(category: str) -> np.ndarray:
+    """Load ground-truth parameters for a dataset category."""
+    df = pd.read_csv(DATA_DIR / f"{category}_best_params.csv")
+    return df.iloc[0].to_numpy(dtype=float)
+
+
+def _mase(found: Sequence[float], truth: Sequence[float]) -> float:
+    """Compute the Mean Absolute Scaled Error (MASE)."""
+    lb = np.asarray(LOWER_BOUNDS, dtype=float)
+    ub = np.asarray(UPPER_BOUNDS, dtype=float)
+    scale = ub - lb
+    found_scaled = (np.asarray(found, dtype=float) - lb) / scale
+    truth_scaled = (np.asarray(truth, dtype=float) - lb) / scale
+    return float(np.mean(np.abs(found_scaled - truth_scaled)))
+
+
+def main() -> None:
+    """Create and save the fitness vs recovery scatter plot."""
+    plt.rcParams.update(
+        {
+            "font.size": 8,
+            "axes.labelsize": 8,
+            "xtick.labelsize": 7.5,
+            "ytick.labelsize": 7.5,
+            "legend.fontsize": 8,
+        }
+    )
+
+    df = pd.read_csv(ROOT / "synthetic_results.csv")
+    df["generator"] = df["dataset"].str.rsplit("_", n=1).str[0]
+    df["optimizer_display"] = df["optimizer"].map(DISPLAY_MAP)
+
+    categories = df["generator"].unique()
+    truth = {cat: _load_ground_truth(cat) for cat in categories}
+    df["mase"] = df.apply(
+        lambda r: _mase(_parse_params(r["params"]), truth[r["generator"]]), axis=1
+    )
+
+    num_points = loadmat(DATA_DIR / "experimental_data.mat")["AAV"].size
+    df["rmse"] = np.sqrt(df["min_sse"] / num_points)
+
+    fig, ax = plt.subplots(figsize=(3.35, 3.0))
+    for name in ORDER:
+        subset = df[df["optimizer_display"] == name]
+        ax.scatter(
+            subset["rmse"],
+            subset["mase"],
+            color=COLORS[name],
+            s=16,
+            label=name,
+        )
+        sns.regplot(
+            data=subset,
+            x="rmse",
+            y="mase",
+            scatter=False,
+            color=COLORS[name],
+            ax=ax,
+            ci=None,
+        )
+
+    rho, pval = spearmanr(df["rmse"], df["mase"])
+    ax.text(
+        0.05,
+        0.95,
+        f"Spearman \u03c1={rho:.2f}\n" f"p={pval:.3f}",
+        transform=ax.transAxes,
+        ha="left",
+        va="top",
+    )
+
+    ax.set_title("Fit Quality vs. Parameter Recovery")
+    ax.set_xlabel("Final RMSE")
+    ax.set_ylabel("Parameter MASE")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(PLOTS_DIR / "fig4_fitness_vs_recovery.pdf", bbox_inches="tight")
+    fig.savefig(
+        PLOTS_DIR / "fig4_fitness_vs_recovery.png", dpi=600, bbox_inches="tight"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add figure generation scripts for experimental fit overlay, convergence, recovery heatmap, and fitness vs. recovery analyses
- each script follows publication-ready styling and uses shared optimizer color mapping

## Testing
- `python -m flake8 generate_figures`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c57afab16483239cbe2ffc02715605